### PR TITLE
feat: add bindlocal skill for development commands

### DIFF
--- a/.claude/skills/bindlocal.skill.md
+++ b/.claude/skills/bindlocal.skill.md
@@ -1,0 +1,110 @@
+# bindlocal
+
+BindLocal Server development helper commands for building, running, and testing the proxy server.
+
+## Commands
+
+### run
+Run the BindLocal server in development mode with logging
+
+```bash
+cargo run
+```
+
+### run-custom
+Run the BindLocal server with custom HTTP and TCP ports
+
+Example: `run-custom 3000 4000` runs HTTP on port 3000 and TCP on port 4000
+
+```bash
+cargo run -- {{args}}
+```
+
+### build
+Build the release version of BindLocal server
+
+```bash
+cargo build --release
+```
+
+### run-release
+Run the release binary
+
+```bash
+./target/release/bindlocal-server
+```
+
+### test
+Run all tests
+
+```bash
+cargo test
+```
+
+### test-verbose
+Run tests with output visible
+
+```bash
+cargo test -- --nocapture
+```
+
+### test-specific
+Run a specific test by name
+
+Example: `test-specific test_name`
+
+```bash
+cargo test {{args}}
+```
+
+### docker-build
+Build Docker image for BindLocal server
+
+```bash
+docker build . -t bindlocal-server:latest
+```
+
+### docker-run
+Run BindLocal server in Docker container
+
+```bash
+docker run -p 8080:8080 -p 9090:9090 bindlocal-server:latest
+```
+
+### check
+Run cargo check to verify code compiles
+
+```bash
+cargo check
+```
+
+### clean
+Clean build artifacts
+
+```bash
+cargo clean
+```
+
+### clippy
+Run clippy for linting
+
+```bash
+cargo clippy -- -D warnings
+```
+
+### fmt
+Format code using rustfmt
+
+```bash
+cargo fmt
+```
+
+## Usage Examples
+
+- `/bindlocal run` - Start server in dev mode (HTTP:8080, TCP:9090)
+- `/bindlocal run-custom 3000 4000` - Start with custom ports
+- `/bindlocal build` - Build release binary
+- `/bindlocal test` - Run all tests
+- `/bindlocal test-specific version_check` - Run specific test
+- `/bindlocal docker-build` - Build Docker image
+- `/bindlocal docker-run` - Run in container

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,101 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+BindLocal Server is a high-performance proxy server that enables secure local development tunneling. It acts as a bridge between web browsers and local development environments, allowing external access to local services through HTTP and TCP protocols.
+
+The server operates with two concurrent components:
+- **HTTP Server** (default port 8080) - Receives HTTP requests from web browsers
+- **TCP Server** (default port 9090) - Establishes socket connections with BindLocal clients
+
+## Build and Development Commands
+
+```bash
+# Build release version
+cargo build --release
+
+# Run in development mode with logging
+cargo run
+
+# Run with custom ports (HTTP port, TCP port)
+cargo run -- 3000 4000
+
+# Run release binary
+./target/release/bindlocal-server
+
+# Run release binary with custom ports
+./target/release/bindlocal-server 3000 4000
+
+# Run tests
+cargo test
+
+# Run specific test
+cargo test test_name
+
+# Run tests with output
+cargo test -- --nocapture
+
+# Docker build
+docker build . -t bindlocal-server:latest
+
+# Docker run
+docker run -p 8080:8080 -p 9090:9090 bindlocal-server:latest
+```
+
+## Architecture
+
+### Core Components
+
+The application uses a shared state model with async message passing:
+
+1. **SharedState** (`src/shared.rs`) - Central state management using Arc<Mutex<HashMap>> for concurrent access
+   - `tcp_connections`: Maps client IDs to channels for sending HTTP requests to TCP clients
+   - `http_connections`: Maps transaction IDs to channels for sending responses back to HTTP clients
+   - `subdomains`: Tracks active subdomain registrations to prevent duplicates
+
+2. **HTTP Server** (`src/http_server.rs`) - Handles incoming HTTP requests
+   - Parses subdomain from Host header to identify target client
+   - Generates unique transaction ID (format: `{client_id}_tx-{random}`)
+   - Creates unbounded channel for receiving response from TCP client
+   - Waits for TCP client to process request and return response
+   - Supports keep-alive connections (checks Connection header)
+
+3. **TCP Server** (`src/tcp_server.rs`) - Manages persistent connections with BindLocal clients
+   - Validates client version on connection (minimum version: 0.0.2)
+   - Handles subdomain registration (auto-generates if not provided or if duplicate)
+   - Receives HTTP requests via channel and forwards to client socket
+   - Reads full HTTP response (handles Content-Length and Transfer-Encoding: chunked)
+   - Sends response back to waiting HTTP connection via channel
+
+### Communication Flow
+
+1. Browser sends HTTP request to HTTP Server
+2. HTTP Server extracts subdomain from Host header to identify client
+3. HTTP Server creates transaction ID and registers a response channel
+4. HTTP Server sends request to TCP Server via SharedState channel
+5. TCP Server forwards request to connected client over socket
+6. Client processes request locally and sends HTTP response back over socket
+7. TCP Server reads complete response and sends to HTTP Server via transaction channel
+8. HTTP Server writes response back to browser
+
+### Important Implementation Details
+
+- The edition in Cargo.toml is set to "2024" (Rust nightly required for Docker build)
+- Both servers run concurrently using `tokio::try_join!`
+- Transaction IDs prevent response routing errors when multiple requests are in flight
+- Client version checking prevents incompatible client connections
+- Subdomain collision handling: appends `-{count}` suffix if duplicate detected
+- Response parsing handles both Content-Length and chunked Transfer-Encoding
+- Special error handling for client app connection failures (CLIENT_ERROR status)
+
+## Testing
+
+Tests are colocated in each module using `#[cfg(test)]`. Key test patterns:
+- Unit tests for parsing and validation functions
+- Tests verify transaction ID generation format
+- Tests validate version checking logic
+- Tests ensure subdomain duplicate detection works correctly
+
+When adding tests, follow the existing pattern of testing individual functions rather than integration tests.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 itsara
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/readme.md
+++ b/readme.md
@@ -92,8 +92,8 @@ The server configuration includes:
 
 - [✅] React application testing
 - [✅] Svelte application testing
-- [🔄] WebSocket support
-- [🔄] HTTPS/SSL termination
+- [✅] WebSocket support
+- [✅] HTTPS/SSL termination
 - [🔄] Load balancing
 - [🔄] Rate limiting
 

--- a/readme.md
+++ b/readme.md
@@ -94,8 +94,6 @@ The server configuration includes:
 - [✅] Svelte application testing
 - [✅] WebSocket support
 - [✅] HTTPS/SSL termination
-- [🔄] Load balancing
-- [🔄] Rate limiting
 
 
 ## Official Website

--- a/src/http_server.rs
+++ b/src/http_server.rs
@@ -193,7 +193,7 @@ fn check_client_app_error(status_resp: String) -> Option<Vec<u8>> {
 }
 
 async fn get_rawdata_delimiter(stream: &mut TcpStream) -> Option<Vec<u8>> {
-    let mut buf = vec![0u8; 1024]; // Initial capacity
+    let mut buf = vec![0u8; 4096]; // Initial capacity
     let mut total_data: Vec<u8> = Vec::new();
     loop {
         let n = stream.read(&mut buf).await.unwrap();

--- a/src/http_server.rs
+++ b/src/http_server.rs
@@ -61,12 +61,13 @@ impl HttpServer {
             };
 
             let headers_str = str::from_utf8(&total_data[..headers_end - 4])?.to_string();
-            let content_length = HttpRequest::parse_content_length(headers_str.clone());
+
             let ip = HttpRequest::parse_check_value_header(headers_str.clone(), "X-Real-IP")
                 .unwrap_or("".to_string());
             let req_txt = HttpRequest::parse_content_request_format(headers_str.clone());
             status_text = format!("{}: {}", ip, &req_txt);
 
+            let content_length = HttpRequest::parse_content_length(headers_str.clone());
             if let Some(body_length) = content_length {
                 let body_data_received = total_data.len() - headers_end;
                 let remaining_body = body_length - body_data_received;
@@ -81,7 +82,6 @@ impl HttpServer {
                         }
                         bytes_read += n;
                     }
-
                     total_data.extend_from_slice(&body_buf);
                 }
             }

--- a/src/http_server.rs
+++ b/src/http_server.rs
@@ -20,6 +20,9 @@ pub struct HttpServer {
 const TWO_DELIMETER_BYTES: &[u8] = b"\r\n\r\n";
 const CRLF: &[u8] = b"\r\n";
 
+const X_REAL_IP: &str = "X-Real-IP";
+const CONNECTION: &str = "Connection";
+
 impl HttpServer {
     pub async fn new(
         addr: &str,
@@ -65,10 +68,10 @@ impl HttpServer {
 
             let headers_str = str::from_utf8(&total_data[..headers_end - 4])?.to_string();
 
-            let ip = HttpRequest::parse_check_value_header(headers_str.clone(), "X-Real-IP")
+            let ip = HttpRequest::parse_check_value_header(headers_str.clone(), X_REAL_IP)
                 .unwrap_or("".to_string());
             let req_txt = HttpRequest::parse_content_request_format(headers_str.clone());
-            status_text = format!("{}: {}", ip, &req_txt);
+            status_text = format!("{ip}: {req_txt}");
 
             let content_length = HttpRequest::parse_content_length(headers_str.clone());
             if let Some(body_length) = content_length {
@@ -124,7 +127,7 @@ impl HttpServer {
             wait_for_tcp_response(rx_http, &mut stream, status_text).await;
 
             if let Some(conn_type) =
-                HttpRequest::parse_check_value_header(headers_str, "Connection")
+                HttpRequest::parse_check_value_header(headers_str, CONNECTION)
             {
                 if conn_type == "close" {
                     break;

--- a/src/http_server.rs
+++ b/src/http_server.rs
@@ -43,7 +43,7 @@ impl HttpServer {
             let shared_state = self.shared_state.clone();
             tokio::spawn(async move {
                 if let Err(e) = Self::handle_connection(socket, shared_state).await {
-                    eprintln!("Error handling HTTP connection: {}", e);
+                    eprintln!("Error handling HTTP connection: {e}");
                 }
             });
         }

--- a/src/http_server.rs
+++ b/src/http_server.rs
@@ -17,6 +17,9 @@ pub struct HttpServer {
     shared_state: SharedState,
 }
 
+const TWO_DELIMETER_BYTES: &[u8] = b"\r\n\r\n";
+const CRLF: &[u8] = b"\r\n";
+
 impl HttpServer {
     pub async fn new(
         addr: &str,
@@ -52,7 +55,7 @@ impl HttpServer {
 
             let mut total_data = get_rawdata_delimiter(&mut stream).await.unwrap();
 
-            let header = total_data.windows(4).position(|w| w == b"\r\n\r\n");
+            let header = total_data.windows(4).position(|w| w == TWO_DELIMETER_BYTES);
             let headers_end = match header {
                 Some(value) => value + 4,
                 None => {
@@ -140,7 +143,7 @@ async fn wait_for_tcp_response(
     match rx_http.recv().await {
         Some(value) => {
             if !value.is_empty() {
-                let header = value.windows(2).position(|w| w == b"\r\n").unwrap();
+                let header = value.windows(2).position(|w| w == CRLF).unwrap();
                 let header_text = String::from_utf8_lossy(&value[0..header]);
                 status_resp = parse_response_header(header_text.to_string());
 
@@ -202,7 +205,7 @@ async fn get_rawdata_delimiter(stream: &mut TcpStream) -> Option<Vec<u8>> {
         }
         total_data.extend_from_slice(&buf[..n]);
 
-        if total_data.windows(4).any(|w| w == b"\r\n\r\n") {
+        if total_data.windows(4).any(|w| w == TWO_DELIMETER_BYTES) {
             break;
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,8 +40,8 @@ impl ServerConfig {
         };
 
         Ok(ServerConfig {
-            http_addr: format!("0.0.0.0:{}", http_port),
-            tcp_addr: format!("0.0.0.0:{}", tcp_port),
+            http_addr: format!("0.0.0.0:{http_port}"),
+            tcp_addr: format!("0.0.0.0:{tcp_port}"),
             http_port,
             tcp_port,
         })

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -40,12 +40,12 @@ impl SharedState {
             match tx_http.send(message) {
                 Ok(_) => true,
                 Err(e) => {
-                    eprintln!("Failed to send message to HTTP client: {}", e);
+                    eprintln!("Failed to send message to HTTP client: {e}");
                     false
                 }
             }
         } else {
-            tracing::error!("cannot connect http client id {}", client_id);
+            tracing::error!("cannot connect http client id {client_id}");
             false
         }
     }

--- a/src/tcp_server.rs
+++ b/src/tcp_server.rs
@@ -49,7 +49,7 @@ impl TcpServer {
         mut shared_state: SharedState,
     ) -> Result<(), Box<dyn std::error::Error>> {
         // check version available
-        let mut first_access = [0u8; 1024];
+        let mut first_access = [0u8; 4096];
         let n = stream.read(&mut first_access).await?;
         if n == 0 {
             return Ok(());
@@ -129,7 +129,7 @@ async fn process_ticket(
     }
 
     let mut buffer: Vec<u8> = Vec::new();
-    let mut tmp = [0u8; 1024];
+    let mut tmp = [0u8; 4096];
     let header_end;
     loop {
         let n = stream.read(&mut tmp).await.unwrap();

--- a/src/tcp_server.rs
+++ b/src/tcp_server.rs
@@ -92,80 +92,16 @@ impl TcpServer {
                 msg = rx_tcp.recv() => {
                     match msg {
                         Some(ticket) => {
-                            let message = ticket.data;
-                            if let Err(e) = stream.write_all(&message).await {
-                                eprintln!("Error sending direct message to TCP client {}: {}", client_id, e);
-                                shared_state.send_to_http_client(client_id.as_str(), vec![]).await;
-                                break;
-                            }
-                            if let Err(e) = stream.flush().await {
-                                eprintln!("Error flushing TCP stream: {}", e);
-                                shared_state.send_to_http_client(client_id.as_str(), vec![]).await;
-                                break;
-                            }
-
-                            let mut buffer = Vec::new();
-                            let mut tmp = [0u8; 1024];
-                            let header_end;
-                            loop {
-                                let n = stream.read(&mut tmp).await?;
-                                if n == 0 {
-                                    return Err("Connection closed before headers".into());
+                            let ticket_name = ticket.name.clone();
+                            match process_ticket(ticket, &mut stream, &client_id).await{
+                                Ok(buffer) => {
+                                    shared_state.send_to_http_client(&ticket_name, buffer).await;
                                 }
-                                buffer.extend_from_slice(&tmp[..n]);
-                                if let Some(pos) = buffer.windows(4).position(|w| w == b"\r\n\r\n") {
-                                    header_end = pos + 4;
-                                    break;
+                                Err(e) => {
+                                    eprintln!("Error processing ticket: {}", e);
+                                    shared_state.send_to_http_client(&ticket_name, vec![]).await;
                                 }
                             }
-                            let header_text = String::from_utf8_lossy(&buffer[..header_end]);
-
-                            let mut headers = HashMap::new();
-                            for line in header_text.lines().skip(1) {
-                                if let Some((k, v)) = line.split_once(": ") {
-                                    headers.insert(k.to_string(), v.to_string());
-                                }
-                            }
-
-                            if let Some(len) = headers.get("Content-Length") {
-                                let len = len.parse::<usize>()?;
-                                while buffer.len() < header_end + len {
-                                    let n = stream.read(&mut tmp).await?;
-                                    if n == 0 {
-                                        break;
-                                    }
-                                    buffer.extend_from_slice(&tmp[..n]);
-                                }
-                            } else if headers
-                                .get("Transfer-Encoding")
-                                .map(|v| v.to_ascii_lowercase())
-                                == Some("chunked".into())
-                            {
-                                loop {
-                                    if buffer[header_end..].windows(5).any(|w| w == b"0\r\n\r\n") {
-                                        break;
-                                    }
-                                    // Read more data
-                                    let n = stream.read(&mut tmp).await?;
-                                    if n == 0 {
-                                        return Err("Connection closed before chunked terminator".into());
-                                    }
-                                    buffer.extend_from_slice(&tmp[..n]);
-                                }
-
-                                if let Some(terminator_pos) = buffer[header_end..]
-                                    .windows(5)
-                                    .position(|w| w == b"0\r\n\r\n")
-                                {
-                                    let end_pos = header_end + terminator_pos + 5; // Include the terminator
-                                    buffer.truncate(end_pos);
-                                }
-                            } else {
-                                // case error
-                                // println!("Error: ERROR CASE");
-                                // case return only header for example: 304, 201
-                            }
-                            shared_state.send_to_http_client(ticket.name.as_str(), buffer).await;
                         },
                         None => {
                             tracing::info!("TCP client application close: [{}] ", client_id);
@@ -179,6 +115,87 @@ impl TcpServer {
         }
         Ok(())
     }
+}
+
+async fn process_ticket(
+    ticket: TicketRequestHttp,
+    stream: &mut TcpStream,
+    client_id: &str,
+) -> Result<Vec<u8>, String> {
+    let message = ticket.data;
+    if let Err(e) = stream.write_all(&message).await {
+        return Err(format!(
+            "Error sending direct message to TCP client {}: {}",
+            client_id, e
+        ));
+    }
+
+    if let Err(e) = stream.flush().await {
+        return Err(format!("Error flushing TCP stream: {}", e));
+    }
+
+    let mut buffer: Vec<u8> = Vec::new();
+    let mut tmp = [0u8; 1024];
+    let header_end;
+    loop {
+        let n = stream.read(&mut tmp).await.unwrap();
+        if n == 0 {
+            return Err("Connection closed before headers".to_string());
+        }
+        buffer.extend_from_slice(&tmp[..n]);
+        if let Some(pos) = buffer.windows(4).position(|w| w == b"\r\n\r\n") {
+            header_end = pos + 4;
+            break;
+        }
+    }
+    let header_text = String::from_utf8_lossy(&buffer[..header_end]);
+
+    let mut headers = HashMap::new();
+    for line in header_text.lines().skip(1) {
+        if let Some((k, v)) = line.split_once(": ") {
+            headers.insert(k.to_string(), v.to_string());
+        }
+    }
+
+    if let Some(len) = headers.get("Content-Length") {
+        let len = len.parse::<usize>().unwrap();
+        while buffer.len() < header_end + len {
+            let n = stream.read(&mut tmp).await.unwrap();
+            if n == 0 {
+                break;
+            }
+            buffer.extend_from_slice(&tmp[..n]);
+        }
+    } else if headers
+        .get("Transfer-Encoding")
+        .map(|v| v.to_ascii_lowercase())
+        == Some("chunked".into())
+    {
+        loop {
+            if buffer[header_end..].windows(5).any(|w| w == b"0\r\n\r\n") {
+                break;
+            }
+            // Read more data
+            let n = stream.read(&mut tmp).await.unwrap();
+            if n == 0 {
+                return Err("Connection closed before chunked terminator".into());
+            }
+            buffer.extend_from_slice(&tmp[..n]);
+        }
+
+        if let Some(terminator_pos) = buffer[header_end..]
+            .windows(5)
+            .position(|w| w == b"0\r\n\r\n")
+        {
+            let end_pos = header_end + terminator_pos + 5; // Include the terminator
+            buffer.truncate(end_pos);
+        }
+    } else {
+        // case error
+        // println!("Error: ERROR CASE");
+        // case return only header for example: 304, 201
+    }
+    Ok(buffer)
 }
 
 fn generate_name() -> String {

--- a/src/tcp_server.rs
+++ b/src/tcp_server.rs
@@ -15,6 +15,8 @@ pub struct TcpServer {
 }
 
 const MINIMUM_CLIENT_VERSION: &str = "0.0.2";
+const TWO_DELIMETER_BYTES: &[u8] = b"\r\n\r\n";
+const ZERO_DELIMETER_BYTES: &[u8] = b"0\r\n\r\n";
 
 impl TcpServer {
     pub async fn new(
@@ -137,7 +139,7 @@ async fn process_ticket(
             eprintln!("Connection closed before headers");
         }
         buffer.extend_from_slice(&tmp[..n]);
-        if let Some(pos) = buffer.windows(4).position(|w| w == b"\r\n\r\n") {
+        if let Some(pos) = buffer.windows(4).position(|w| w == TWO_DELIMETER_BYTES) {
             header_end = pos + 4;
             break;
         }
@@ -166,7 +168,7 @@ async fn process_ticket(
         == Some("chunked".into())
     {
         loop {
-            if buffer[header_end..].windows(5).any(|w| w == b"0\r\n\r\n") {
+            if buffer[header_end..].windows(5).any(|w| w == ZERO_DELIMETER_BYTES) {
                 break;
             }
             // Read more data
@@ -179,7 +181,7 @@ async fn process_ticket(
 
         if let Some(terminator_pos) = buffer[header_end..]
             .windows(5)
-            .position(|w| w == b"0\r\n\r\n")
+            .position(|w| w == ZERO_DELIMETER_BYTES)
         {
             let end_pos = header_end + terminator_pos + 5; // Include the terminator
             buffer.truncate(end_pos);
@@ -211,7 +213,6 @@ fn parse_version(version_str: &str) -> Option<(u32, u32, u32)> {
     }
 }
 
-/// Checks if the `first_access` version is greater than or equal to the `current_version`.
 fn check_available_version(first_access: &str, current_version: &str) -> bool {
     let first_parsed = match parse_version(first_access) {
         Some(v) => v,

--- a/src/tcp_server.rs
+++ b/src/tcp_server.rs
@@ -33,14 +33,14 @@ impl TcpServer {
     pub async fn run(self) -> Result<(), Box<dyn std::error::Error>> {
         loop {
             let (socket, addr) = self.listener.accept().await?;
-            tracing::info!("New TCP connection from: {}", addr);
+            tracing::info!("New TCP connection from: {addr}");
 
             let shared_state = self.shared_state.clone();
 
             // Spawn a new task for each TCP connection
             tokio::spawn(async move {
                 if let Err(e) = Self::handle_tcp_connection(socket, shared_state).await {
-                    eprintln!("Error handling TCP connection: {}", e);
+                    eprintln!("Error handling TCP connection: {e}");
                 }
             });
         }
@@ -70,7 +70,7 @@ impl TcpServer {
             client_id = sub_domain_name.to_string();
             let mut cnt = 1;
             while shared_state.check_duplicate_subdomain(client_id.clone()) {
-                client_id = format!("{}-{}", client_id, cnt);
+                client_id = format!("{client_id}-{cnt}");
                 cnt += 1;
             }
         } else {
@@ -79,14 +79,14 @@ impl TcpServer {
                 client_id = generate_name();
             }
         }
-        tracing::info!("client id [{}]", client_id);
+        tracing::info!("client id [{client_id}]");
         let (tx_tcp, mut rx_tcp) = mpsc::unbounded_channel::<TicketRequestHttp>();
         shared_state
             .register_tcp_client(client_id.to_string(), tx_tcp)
             .await;
 
         // Send welcome message
-        let welcome = format!("{}", client_id);
+        let welcome = format!("{client_id}");
         stream.write_all(welcome.as_bytes()).await?;
 
         loop {
@@ -97,7 +97,7 @@ impl TcpServer {
                             process_ticket(ticket, &mut stream, &client_id, &mut shared_state).await;
                         },
                         None => {
-                            tracing::info!("TCP client application close: [{}] ", client_id);
+                            tracing::info!("TCP client application close: [{client_id}] ");
                             shared_state
                                 .unregister_tcp_client(client_id.as_str()).await;
                             break;
@@ -119,14 +119,13 @@ async fn process_ticket(
     let message = ticket.data;
     if let Err(e) = stream.write_all(&message).await {
         eprintln!(
-            "Error sending direct message to TCP client {}: {}",
-            client_id, e
+            "Error sending direct message to TCP client {client_id}: {e}"
         );
         shared_state.send_to_http_client(&ticket.name, vec![]).await;
     }
 
     if let Err(e) = stream.flush().await {
-        eprintln!("Error flushing TCP stream: {}", e);
+        eprintln!("Error flushing TCP stream: {e}");
         shared_state.send_to_http_client(&ticket.name, vec![]).await;
     }
 


### PR DESCRIPTION
## Summary
- Added Claude Code skill file for BindLocal Server development workflows
- Provides quick access to common Rust cargo commands (build, run, test)
- Includes Docker commands for containerized deployment
- Supports custom port configuration and verbose test output

## Commands Included
- `run` - Start dev server with default ports
- `run-custom` - Start with custom HTTP/TCP ports
- `build` - Build release binary
- `test` / `test-verbose` / `test-specific` - Testing commands
- `docker-build` / `docker-run` - Docker operations
- `check` / `clippy` / `fmt` - Code quality tools

## Test plan
- [x] Skill file created in `.claude/skills/` directory
- [ ] Test skill commands with `/bindlocal <command>`
- [ ] Verify all cargo commands work as expected
- [ ] Test Docker commands if Docker is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)